### PR TITLE
fixes for RFM95, add option to offset battery voltage

### DIFF
--- a/WioLoRaWanFieldTester.ino
+++ b/WioLoRaWanFieldTester.ino
@@ -164,6 +164,9 @@ void loop(void) {
       #if HWTARGET == RFM95
         uint32_t v = analogRead(LIPO_ADC);
         v = 2*( 3300 * v ) / 1024;  // should be 2230 ...
+        #ifdef LIPO_OFFSET_MV
+          v += LIPO_OFFSET_MV;
+        #endif
         state.batVoltage = v;
         state.batPercent = batteryPercent(state.batVoltage);
       #elif HWTARGET == LORAE5

--- a/config.h
+++ b/config.h
@@ -45,6 +45,16 @@
   #define RFM95_DIO_0     3
   #define RFM95_DIO_1     2
   #define LIPO_ADC        A4
+
+  // Offset to add when calculating battery percent remaining (in mv) 
+  // Sometimes R/R divider may not accurate and battery voltage can be
+  // shifted, so percent calculation may be wrong, this offset is added
+  // on each calculation to fix it, best way to know this one if to fully
+  // charge battery should be 4.2V, and read on GPS screen battery voltage
+  // to view difference, in my case reading was 3950mV so added 250mV offset
+  // it's empiric of course, not best but better than nothing
+  // #define LIPO_OFFSET_MV 250 
+
 // 3 - select possible options
   #define WITH_GPS
   #define WITH_LIPO

--- a/storeConf.cpp
+++ b/storeConf.cpp
@@ -186,7 +186,7 @@ void storeConfig() {
 
   bool readConfigFromBackup() {
     state.cPwr = 16;
-    state.cSf = 7;
+    state.cSf = DR_SF7;
     return false;
   }
   

--- a/storeConf.cpp
+++ b/storeConf.cpp
@@ -185,6 +185,8 @@ void storeConfig() {
 #else
 
   bool readConfigFromBackup() {
+    state.cPwr = 16;
+    state.cSf = 7;
     return false;
   }
   

--- a/storeConf.cpp
+++ b/storeConf.cpp
@@ -18,6 +18,7 @@
  *  Author : Paul Pinault (disk91.com)
  */ 
 #include <FlashStorage.h>
+#include "config.h"
 #include "testeur.h"
 #include "ui.h"
 #include "LoRaCom.h"
@@ -106,6 +107,7 @@ void storeConfig() {
 
 #if HWTARGET == LORAE5
 
+  #error "******"
   // Use the LoRae5 internal storage to save the config and support firmware update
   bool readConfigFromBackup() {
   
@@ -187,7 +189,7 @@ void storeConfig() {
     return false;
   }
   
-  bool storeConfigFromBackup() {
+  bool storeConfigToBackup() {
   
   }
 

--- a/storeConf.cpp
+++ b/storeConf.cpp
@@ -107,7 +107,6 @@ void storeConfig() {
 
 #if HWTARGET == LORAE5
 
-  #error "******"
   // Use the LoRae5 internal storage to save the config and support firmware update
   bool readConfigFromBackup() {
   

--- a/storeConf.cpp
+++ b/storeConf.cpp
@@ -18,6 +18,7 @@
  *  Author : Paul Pinault (disk91.com)
  */ 
 #include <FlashStorage.h>
+#include <lmic.h>
 #include "config.h"
 #include "testeur.h"
 #include "ui.h"


### PR DESCRIPTION
- Fix compilation issue for RFM95
- Fix hazardous default values for Power and SF for RFM95 even if I love the idea of SF255 :-)
- Added `#define` option to offset battery voltage `LIPO_OFFSET_MV` (default disabled)

Sometimes R/R divider may not accurate and battery voltage can be  shifted, so percent calculation may be wrong, this offset is added on each measure to fix it
Best way to know this one if to fully charge battery (should be 4.2V), and read on GPS screen battery voltage to view difference, in my case reading was 3950mV so added 250mV offset 
It's empiric of course, not best but better than nothing
