### PR TITLE
DIY with Wio Battery Chassis

### DIFF
--- a/WioLoRaWanFieldTester.ino
+++ b/WioLoRaWanFieldTester.ino
@@ -26,9 +26,9 @@
 #include "testeur.h"
 #include "gps.h"
 
-#if HWTARGET == LORAE5 && defined WITH_LIPO
+#if WITH_WIO_BATTERY_PACK
   #include <SparkFunBQ27441.h>
-  const unsigned int BATTERY_CAPACITY = 600; 
+  const unsigned int BATTERY_CAPACITY = 650; 
 #endif
 
 
@@ -78,7 +78,7 @@ void setup() {
      uint32_t s = millis();
      while ( !Serial && (millis() - s) < 3000); 
   #endif
-  #if HWTARGET == LORAE5 && defined WITH_LIPO
+  #if WITH_WIO_BATTERY_PACK
      if ( lipo.begin() ) {
        state.batOk = true;
        lipo.setCapacity(BATTERY_CAPACITY);
@@ -170,7 +170,7 @@ void loop(void) {
   
   #ifdef WITH_LIPO
     if ( batUpdateTime > 1000 ) {
-      #if HWTARGET == RFM95
+      #if HWTARGET == RFM95 && WITH_WIO_BATTERY_PACK == 0
         uint32_t v = analogRead(LIPO_ADC);
         v = 2*( 3300 * v ) / 1024;  // should be 2230 ...
         #ifdef LIPO_OFFSET_MV
@@ -178,7 +178,7 @@ void loop(void) {
         #endif
         state.batVoltage = v;
         state.batPercent = batteryPercent(state.batVoltage);
-      #elif HWTARGET == LORAE5
+      #elif WITH_WIO_BATTERY_PACK == 1
         if ( state.batOk ) {
           unsigned int soc = lipo.soc();  // Read state-of-charge (%)
           unsigned int volts = lipo.voltage(); // Read battery voltage (mV)

--- a/config.h
+++ b/config.h
@@ -31,6 +31,7 @@
 #define LORAE5     1      // Make sure the board ROLE is SLAVE
 
 // 2 - select the target board, original one based on RFM95 or Seed LoRa E5 version
+// go to 3.1, and uncomment that line, if you have a wio battery pack
 #define HWTARGET   LORAE5
 
 #if HWTARGET == LORAE5
@@ -60,6 +61,11 @@
   #define WITH_GPS
   #define WITH_LIPO
 #endif
+
+// to allow using wio battery pack with DIY RFM95 LoRa module
+#define WITH_WIO_BATTERY_PACK (HWTARGET == LORAE5 && defined WITH_LIPO)
+// 3.1 - if you have a DIY with the Wio battery pack, uncomment this line to get Wio battery pack state of charge
+// #define WITH_WIO_BATTERY_PACK 1
 
 // 4 - Active on of the possible Splash screen ( or none or both )
 #define WITH_SPLASH         1

--- a/doc/DEVELOPMENT.md
+++ b/doc/DEVELOPMENT.md
@@ -20,7 +20,7 @@ https://files.seeedstudio.com/arduino/package_seeeduino_boards_index.json
 #### RFM95 version
 * LoRaWAN - MCCI LoRaWAN LMIC library (by IBM, Matthjs Kooljman…) version 3.3.0
 
-#### LoRa-E5 version
+#### RFM95 or LoRa-E5 version with Wio Battery Chassis
 * Battery Chassis - Sparkfun BQ27441
 
 #### Later
@@ -102,6 +102,7 @@ Different setups needs to be performed in Libraries (so you know why I don't rea
 #define WITH_LIPO                     // if defined the LiPo status & charging code is enable
 
 ```
+If you have a DIY with Wio Battery Chassis uncomment this line at 3.1: `#define WITH_WIO_BATTERY_PACK 1`, and you can read the state of charge of the Wio Battery.
 
 - The `key.h file contains the LoRaWAN credential. When all set to 0, the device will expect a serial port configuration as seen in the setup.
 

--- a/ui.cpp
+++ b/ui.cpp
@@ -91,7 +91,17 @@ void displayTitle() {
     sprintf(title,"Wio LoRaWan Field Tester");
     tft.drawString(title,(320-200)/2, 85, GFXFF);  
     sprintf(title,"Version %s (%s)", VERSION, model==LORAE5 ? "LoRaE5" : "RFM95");
-    tft.drawString(title,(320-180)/2, 115, GFXFF);  
+    tft.drawString(title,(320-180)/2, 115, GFXFF);
+#if WITH_WIO_BATTERY_PACK
+    sprintf(title,"With Wio Terminal Chassis Battery");
+    tft.drawString(title,(320-260)/2, 145, GFXFF);
+#elif defined WITH_LIPO
+    sprintf(title,"With internal LiPo Battery");
+    tft.drawString(title,(320-190)/2, 145, GFXFF);
+#else
+    sprintf(title,"No battery");
+    tft.drawString(title,(320-80)/2, 145, GFXFF);
+#endif
     sprintf(title,"WIO_FT_%02X%02X%02X%02X%02X", loraConf.deveui[3],loraConf.deveui[4], loraConf.deveui[5], loraConf.deveui[6], loraConf.deveui[7]);
     tft.drawString(title,(320-160)/2, 180, GFXFF);
 }
@@ -1152,7 +1162,20 @@ void refreshGpsDetails() {
     sprintf(sTmp,"Hdop:      %d.%d Sats: %d", gps.hdop/100,gps.hdop-100*(gps.hdop/100), gps.sats);
     tft.drawString(sTmp,TXT_ALL_OFF_X,TXT_QUA_OFF_Y,GFXFF);
 
-    sprintf(sTmp,"Battery:   %d mV (%d%%)",state.batVoltage, state.batPercent);
+    // switch text color based on battery state
+    if ( state.batPercent > 50 ) tft.setTextColor(TFT_GREEN);
+    else if ( state.batPercent > 20 ) tft.setTextColor(TFT_ORANGE);
+    else tft.setTextColor(TFT_RED);
+ 
+#if WITH_WIO_BATTERY_PACK
+    sprintf(sTmp,"Battery(w):%d mV (%d%%)",state.batVoltage, state.batPercent);
+#elif defined WITH_LIPO 
+    // internal battery's voltage
+    sprintf(sTmp,"Battery(i):%d mV (%d%%)",state.batVoltage, state.batPercent);
+#else 
+    // I think anything shorter (like "no battery" or "no battery voltage") might be misleading
+    sprintf(sTmp, "No battery defined in build");
+#endif
     tft.drawString(sTmp,TXT_ALL_OFF_X,TXT_BAT_OFF_Y,GFXFF);
   #ifdef DEBUGGPS
   }


### PR DESCRIPTION
With this change someone with a DIY RFM95 and a Wio battery pack can read the state of charge from the Wio battery pack. Why: when I assembled mine, the MCP73831 and suitably sized LiPo was out of stock everywhere. Maybe not an issue now, but maybe helpful for some...

Usage: in config.h set HWTARGET to RFM95 and uncomment the WITH_WIO_BATTERY_PACK line.
`#define HWTARGET   RFM95`
`#define WITH_WIO_BATTERY_PACK 1`

Tested with my DIY with Wio battery pack and without the Wio battery pack. Works both ways, only difference is battery voltage display shows 0V, if no Wio battery pack is installed.

Also a small tweaks on the GPS / status screen: before if GPS signal was weak, the battery voltage was also in red/orange. Now the battery voltage follows the state of charge colors like in the in the battery gauge line.

Example with no GPS signal (not visible on the image, but this is a DIY with Wio battery pack):
![20220820_094018](https://user-images.githubusercontent.com/844331/185734871-09fad2cf-e5ad-4084-9a33-a462cf99d08d.jpg)

