### PR TITLE
PlatformIO support including automated library patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.pio

--- a/apply_patches.py
+++ b/apply_patches.py
@@ -1,0 +1,39 @@
+from os.path import join, isfile, isdir
+
+Import("env")
+
+FRAMEWORK_DIR = env.PioPlatform().get_package_dir("framework-arduino-samd-seeed")
+LIBS_DIRS = env.GetLibSourceDirs()
+
+def find_library(name):
+    for dir in LIBS_DIRS:
+        lib_dir = join(dir, name)
+        if isdir(lib_dir):
+            return lib_dir
+    return None
+
+def patch_file(file, patch):
+    if isfile(file) and isfile(patch):
+        if not isfile(file + ".patched"):
+            env.Execute("patch -p0 -N -s \"%s\" \"%s\"" % (file, patch))
+            env.Execute("touch \"%s.patched\"" % file)
+
+# Patch Adafruit_GPS library
+folder = find_library("Adafruit GPS Library")
+if folder:
+    file = join(folder, "src", "Adafruit_GPS.h")
+    patch = join("patches", "Adafruit_GPS.h.patch")
+    patch_file(file, patch)
+
+# Patch MCCI LoRaWAN LMIC library
+folder = find_library("MCCI LoRaWAN LMIC library")
+if folder:
+    file = join(folder, "project_config", "lmic_project_config.h")
+    patch = join("patches", "lmic_project_config.h.patch")
+    patch_file(file, patch)
+
+# Patch SoftwareSerial library
+file = join(FRAMEWORK_DIR, "libraries", "SoftwareSerial", "SoftwareSerial.h")
+patch = join("patches", "SoftwareSerial.h.patch")
+patch_file(file, patch)
+

--- a/patches/Adafruit_GPS.h.patch
+++ b/patches/Adafruit_GPS.h.patch
@@ -1,0 +1,13 @@
+diff --git a/src/Adafruit_GPS.h b/src/Adafruit_GPS.h
+index 4043c04..586e88d 100644
+--- a/src/Adafruit_GPS.h
++++ b/src/Adafruit_GPS.h
+@@ -24,6 +24,8 @@
+ #ifndef _ADAFRUIT_GPS_H
+ #define _ADAFRUIT_GPS_H
+ 
++#define ESP8266
++
+ /**************************************************************************/
+ /**
+  Comment out the definition of NMEA_EXTENSIONS to make the library use as

--- a/patches/SoftwareSerial.h.patch
+++ b/patches/SoftwareSerial.h.patch
@@ -1,0 +1,13 @@
+diff --git a/SoftwareSerial.new b/SoftwareSerial.h
+index c678a4d..7dbeda2 100644
+--- a/SoftwareSerial.new
++++ b/SoftwareSerial.h
+@@ -35,7 +35,7 @@
+ #define portInputReg(port)    ( &(port->IN) )
+ #define portModeReg(port)     ( &(port->DIR) )
+ 
+-#define _SS_MAX_RX_BUFF 64 // RX buffer size
++#define _SS_MAX_RX_BUFF 128 // RX buffer size
+ #ifndef GCC_VERSION
+ #define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+ #endif

--- a/patches/lmic_project_config.h.patch
+++ b/patches/lmic_project_config.h.patch
@@ -1,0 +1,21 @@
+diff --git a/project_config/lmic_project_config.h b/project_config/lmic_project_config.h
+index 732e6e6..de84e61 100644
+--- a/project_config/lmic_project_config.h
++++ b/project_config/lmic_project_config.h
+@@ -1,10 +1,13 @@
+ // project-specific definitions
+-//#define CFG_eu868 1
+-#define CFG_us915 1
++#define CFG_eu868 1
++//#define CFG_us915 1
+ //#define CFG_au915 1
+ //#define CFG_as923 1
+ // #define LMIC_COUNTRY_CODE LMIC_COUNTRY_CODE_JP	/* for as923-JP */
+ //#define CFG_kr920 1
+ //#define CFG_in866 1
+ #define CFG_sx1276_radio 1
+ //#define LMIC_USE_INTERRUPTS
++#define LMIC_LORAWAN_SPEC_VERSION   LMIC_LORAWAN_SPEC_VERSION_1_0_2
++#define DISABLE_BEACONS
++#define DISABLE_PING
+\ No newline at end of file

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,26 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+[platformio]
+src_dir = .
+
+[env:seeed_wio_terminal]
+platform = atmelsam
+board = seeed_wio_terminal
+framework = arduino
+#platform_packages = framework-arduino-samd-seeed@https://github.com/Seeed-Studio/ArduinoCore-samd.git
+lib_deps = 
+    sparkfun/SparkFun BQ27441 LiPo Fuel Gauge Arduino Library
+    ricmoo/QRCode
+    https://github.com/cmaglie/FlashStorage
+    https://github.com/adafruit/Adafruit_GPS#1.5.4
+    mcci-catena/MCCI LoRaWAN LMIC library@3.3.0
+build_unflags = -DROLE=0
+build_flags = -DROLE=1
+extra_scripts = pre:apply_patches.py


### PR DESCRIPTION
This pull requests provide PlatformIO support.

PlatformIO will install all the required dependencies (board, framework and libraries) automatically.
After installation but before building the firmware, it will also patch the libraries following the instructions in the DEVELOPMENT.md page.
The `platformio.ini` file is configured to build using slave role and the patch for the LMIC library configures the device using EU868 band, but both are easy to change without having to mess with code in 3rd party dependencies.