### PR TITLE
Automatically scale Distance graph Y axis, starting at 1km default

### DIFF
--- a/ui.h
+++ b/ui.h
@@ -70,6 +70,7 @@ typedef struct s_ui {
   bool    alertMode;        // LiPo alert is on
   int     lockMode;         // lock keyboard (1) with screen off (2)
   uint32_t lastGpsUpdateTime; // Last GPS display update time
+  uint16_t lastDistanceMax;  // Last auto-scale val
 } ui_t;
 
 extern ui_t ui;


### PR DESCRIPTION
The default Distance graph was 55km max which made the near gateways a little harder to read. Change the default to 1km and automatically scale it up if needed. 