### PR TITLE
Flush E5 serial even if we are not in a cmd mode

### DIFF
--- a/LoRaComE5.cpp
+++ b/LoRaComE5.cpp
@@ -63,6 +63,7 @@ typedef struct {
 loraE5_t loraContext;
 
 bool processATResponse();
+bool processTx();
 
 /**
  * Execute an AT command with a timeout
@@ -149,9 +150,33 @@ int indexOf(const char * str, const char * ref) {
  */
 bool processATResponse() {
 
-  // nothing to be done
-  if ( !loraContext.runningCommand ) return true;
-
+  // nothing to be done, flush serial
+  if ( !loraContext.runningCommand ) {
+    while ( SERIALE5.available() > 0 ) {
+      char c = SERIALE5.read();
+      if ( (c == '\0' || c == '\r' || c == '\n' ) ) {
+        if ( loraContext.respIndex > 0 ) {
+          // process line response outside run cmd context
+          loraContext.bufResponse[loraContext.respIndex] = '\0';
+          LOGLORALN((loraContext.bufResponse));
+          
+          if ( startsWith(loraContext.bufResponse, "+MSG:" ) ) {
+              processTx();    // TX downlink response
+          }
+        }
+        loraContext.respIndex = 0;
+      } else {
+        if ( loraContext.respIndex < 2*MAX_RESP_BUF_SZ ) {
+          loraContext.bufResponse[loraContext.respIndex] = c;
+          loraContext.respIndex++;
+        } else {
+          LOGLN(("Response size overflow"));
+          loraContext.respIndex = 0;
+        }
+      }
+    }
+    return true;
+  }
   // manage timeout
   uint32_t duration  = millis() - loraContext.startTime;   // overflow after 50D. risk taken.
   if ( duration > loraContext.maxDuration ) {
@@ -502,25 +527,37 @@ uint32_t txDurationEstimate(uint8_t _dr) {
 // 12:23:33.627 -> +CMSGHEX: Done
 
 bool processTx(void) {
-  if ( startsWith(loraContext.bufResponse,"+CMSGHEX: RXWIN*, RSSI") ) {
-     int s = indexOf(loraContext.bufResponse,"RSSI ");
+  char *buf = loraContext.bufResponse;
+
+  if ( startsWith(buf, "+CMSGHEX: *") ) {
+    buf += strlen("+CMSGHEX: ");
+  } else if ( startsWith(buf, "+MSGHEX: *") ) {
+    buf += strlen("+MSGHEX: ");
+  } else if ( startsWith(buf, "+MSG: *") ) {
+    buf += strlen("+MSG: ");
+  } else {
+    return false; // not a TX response
+  }
+
+  if ( startsWith(buf,"RXWIN*, RSSI") ) {
+     int s = indexOf(buf,"RSSI ");
      loraContext.lastRssi = 0.0;
      loraContext.lastSnr = 0.0;
      if ( s > 0 ) {
         char sRssi[10];
-        if ( extractNumber(&loraContext.bufResponse[s], sRssi,10) ) {
+        if ( extractNumber(&buf[s], sRssi,10) ) {
            loraContext.lastRssi = atof(sRssi);
         }
      }
-     s = indexOf(loraContext.bufResponse,"SNR ");
+     s = indexOf(buf,"SNR ");
      if ( s > 0 ) {
         char sSnr[10];
-        if ( extractNumber(&loraContext.bufResponse[s], sSnr,10) ) {
+        if ( extractNumber(&buf[s], sSnr,10) ) {
            loraContext.lastSnr = atof(sSnr);
         }
      }
      loraContext.hasAcked = true;
-  } else if (startsWith(loraContext.bufResponse,"+CMSGHEX: Done")) {
+  } else if (startsWith(buf,"Done") ) {
     loraContext.elapsedTime = millis() - loraContext.startTime;
     if ( loraContext.hasAcked ) {
       uint8_t retries = loraContext.elapsedTime / txDurationEstimate(loraContext.lastDr); // really approximative approach
@@ -568,29 +605,29 @@ bool processTx(void) {
       state.hasRefreshed = true;
       state.cState = JOINED;
     }
-  } else if ( startsWith(loraContext.bufResponse,"+CMSGHEX: FPEND") ) {
+  } else if ( startsWith(buf,"FPEND") ) {
     // downlink pending
     loraContext.downlinkPending = true;
-  } else if ( startsWith(loraContext.bufResponse,"+CMSGHEX: PORT: *; RX: ") ) {
+  } else if ( startsWith(buf,"PORT: *; RX: ") ) {
     // downlink content
-    int s = indexOf(loraContext.bufResponse,"PORT: ");
+    int s = indexOf(buf,"PORT: ");
     int port=0;
     if ( s > 0 ) {
        char sPort[10];
-       if ( extractNumber(&loraContext.bufResponse[s], sPort,10) ) {
+       if ( extractNumber(&buf[s], sPort,10) ) {
           port = atoi(sPort);
        }
     }
-    s = indexOf(loraContext.bufResponse,"RX: \"");
+    s = indexOf(buf,"RX: \"");
     if ( s > 0 ) {
        uint8_t sz = MAX_DOWNLINK_BUF;
-       if ( extractHexStr(&loraContext.bufResponse[s], loraContext.bufDownlink, &sz) ) {
+       if ( extractHexStr(&buf[s], loraContext.bufDownlink, &sz) ) {
           if ( sz == 6 && port == 2 ) {
             loraContext.gotDownlink = true;
           }
        }
     }
-  } else if ( startsWith(loraContext.bufResponse,"+CMSGHEX: Length err") ) {
+  } else if ( startsWith(buf,"Length err") ) {
     // current request is not corresponding to the max frame size
     // this may be due to a LoRaWan additional content like MAC command
     state.cState = EMPTY_DWNLINK; // next time we send a smaller frame

--- a/testeur.cpp
+++ b/testeur.cpp
@@ -98,7 +98,8 @@ void initState() {
   #endif
 }
 
-void addInBuffer(int16_t rssi, int16_t snr, uint8_t retry, uint16_t seq, bool lost) {
+uint8_t addInBuffer(int16_t rssi, int16_t snr, uint8_t retry, uint16_t seq, bool lost) {
+  uint8_t idx = state.writePtr;
   state.seq[state.writePtr] = seq;
   if ( ! lost ) { 
       state.rssi[state.writePtr] = rssi;
@@ -121,6 +122,7 @@ void addInBuffer(int16_t rssi, int16_t snr, uint8_t retry, uint16_t seq, bool lo
   } else {
     state.elements++;
   }
+  return idx;
 }
 
 uint8_t getIndexInBuffer(int i) {

--- a/testeur.h
+++ b/testeur.h
@@ -98,7 +98,7 @@ void initState();
 void tst_setPower(int8_t pwr);
 void tst_setSf(uint8_t sf);
 void tst_setRetry(uint8_t retry);
-void addInBuffer(int16_t rssi, int16_t snr, uint8_t retry, uint16_t seq, bool lost);
+uint8_t addInBuffer(int16_t rssi, int16_t snr, uint8_t retry, uint16_t seq, bool lost);
 uint8_t getIndexInBuffer(int i);
 uint8_t getLastIndexWritten();
 uint8_t getIndexBySeq(uint16_t seq);


### PR DESCRIPTION
In some scenarios the firmware returns the downlink after CMSGHEX is done and the current code will ignore that. It also returns it with the +MSG: prefix which seems to be undocumented behaviour. I have my E5 in ABP mode, I didnt notice it when it was in OTAA mode.

<manual tx push #1>
```
AT+PORT=1
+PORT: 1
AT+CMSGHEX=XXXXXXXXXXXXXXXXXXXX
+CMSGHEX: Start
+CMSGHEX: Wait ACK
+CMSGHEX: Done
```

<manual tx push #2>
```
AT+PORT=1
+MSG: FPENDING
+MSG: ACK Received
+MSG: PORT: 2; RX: "006B93242402"
+MSG: RXWIN1, RSSI -56, SNR 2.0
+MSG: Done
+PORT: 1
AT+CMSGHEX=XXXXXXXXXXXXXXXXXXXX
+CMSGHEX: Start
+CMSGHEX: Wait ACK
+CMSGHEX: Done
```

As we can see there were bytes waiting on the serial port with our missing downlink. The AT+PORT flushes these while looking for "+PORT: 1" and they never get processed.

The code now flushes serial even if we are not in command mode and will look for TX messages. Change processTx() to strip the start as it could be any of CMSGHEX/MSGHEX/MSG. Note that MSGHEX sending would never have worked before.

Now the following is read and processed on a Tx.
```
AT+PORT=1
+PORT: 1
AT+CMSGHEX=XXXXXXXXXXXXXXXXXXXX
+CMSGHEX: Start
+CMSGHEX: Wait ACK
+CMSGHEX: Done
+MSG: ACK Received
+MSG: PORT: 2; RX: "007198242402"
+MSG: RXWIN1, RSSI -61, SNR 3.0
+MSG: Done
```

